### PR TITLE
Update LaudesOP.txt

### DIFF
--- a/web/www/horas/English/Ordinarium/LaudesOP.txt
+++ b/web/www/horas/English/Ordinarium/LaudesOP.txt
@@ -4,9 +4,10 @@ $Deus in adjutorium
 
 #Psalmi
 
-#Canticle of Zechari'ah
-#Luke 1
-&ant_Benedictus(1)
+#Capitulum Hymnus Versus
+
+#Canticum: Benedictus
+&ant_Benedictus
 &canticum(1)
 &Gloria
 &ant_Benedictus(2)


### PR DESCRIPTION
Current LaudesOP file is missing the English translation  of the Capitulum, Hymnus, and Versus.  This places the  C, H, V in the appropriate position.  Also cleans up the  file to more closely match the 1960 Roman display and  the Latin formatting (retitle of "Canticle of Zechariah"  to "Canticum: Benedictus" and drops the repeat entry of  "Luke 1").